### PR TITLE
h2サーバモードをtcpからfileに変更。

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,12 @@ IntelliJ で Mavenウィンドウ の `Execute Maven Goal` から、以下に記
 - `Execute Maven Goal` を開くには、Mavenウィンドウ上部の青い"m"の付いたアイコンをクリックします。<br>
 `Command line` に実行したいコマンドを入力して `Execute`ボタンで実行します。
 
-1. データベース(h2)を起動する。<br>
-    ```sh
-    exec:java@h2-start
-    ```
-
-2. db/ddl配下のDDLの実行からダンプファイル作成までを行う。
+1. db/ddl配下のDDLの実行からダンプファイル作成までを行う。
     ```sh
     -P gsp clean generate-resources
     ```
 
-3. アプリケーションをビルドして起動する。
+2. アプリケーションをビルドして起動する。
     ```sh
     clean compile waitt:run
     ```

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <!-- gsp-dba-maven-pluginが使用するデータベース設定 -->
     <nablarch.db.jdbcDriver>org.h2.Driver</nablarch.db.jdbcDriver>
-    <nablarch.db.url>jdbc:h2:tcp://localhost:9092/./db/tiscon4</nablarch.db.url>
+    <nablarch.db.url>jdbc:h2:file:./db/tiscon4</nablarch.db.url>
     <nablarch.db.adminUser>sa</nablarch.db.adminUser>
     <nablarch.db.user>tiscon4</nablarch.db.user>
     <nablarch.db.password>p@ssw0rd</nablarch.db.password>

--- a/src/main/resources/env.config
+++ b/src/main/resources/env.config
@@ -6,7 +6,7 @@ nablarch.connectionFactory.jndiResourceName=
 nablarch.db.jdbcDriver=org.h2.Driver
 
 # JDBC接続URL(DataSourceを直接使用する際の項目)
-nablarch.db.url=jdbc:h2:tcp://localhost:9092/./db/tiscon4
+nablarch.db.url=jdbc:h2:file:./db/tiscon4;AUTO_SERVER=true
 
 # DB接続ユーザ名(DataSourceを直接使用する際の項目)
 nablarch.db.user=tiscon4


### PR DESCRIPTION
* `exec:java@h2-start`実行無しで、アプリケーションが実行できることを確認
* `exec:java@h2-console`も問題無し
* DB登録も問題無し

* `README.md`からデータベース(h2)を起動する手順を削除。